### PR TITLE
feat(HACBS-1552): add upload_sbom script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV HOME=/tekton/home
 # The ~ dir seems to be mounted over in tekton tasks, so put in /home
 RUN git clone https://github.com/redhat-appstudio/release-service-utils /home/release-service-utils
 
-# Copy the create_container_image script so we can use it without extension in release-service-bundles
+# Copy the create_container_image and upload_sbom scripts so we can use them without extension in release-service-bundles
 RUN cp /home/release-service-utils/pyxis/create_container_image.py /home/release-service-utils/pyxis/create_container_image
+RUN cp /home/release-service-utils/pyxis/upload_sbom.py /home/release-service-utils/pyxis/upload_sbom
 
 ENV PATH=$PATH:/home/release-service-utils/pyxis

--- a/pyxis/test_upload_sbom.py
+++ b/pyxis/test_upload_sbom.py
@@ -1,0 +1,416 @@
+import pytest
+from unittest.mock import patch, call
+
+from upload_sbom import (
+    upload_sbom,
+    get_image,
+    create_content_manifest,
+    get_existing_components,
+    get_existing_bom_refs,
+    create_content_manifest_component,
+    get_existing_component_count,
+    load_sbom_components,
+    check_bom_ref_duplicates,
+    convert_keys,
+    remove_unsupported_fields,
+    UNSUPPORTED_FIELDS,
+)
+
+GRAPHQL_API = "myapiurl"
+IMAGE_ID = "123456abcd"
+SBOM_PATH = "mypath"
+MANIFEST_ID = "abcd1234"
+COMPONENT_ID = "abcd2222"
+IMAGE_DICT = {"_id": IMAGE_ID}
+COMPONENT_DICT = {"bom_ref": "mybomref"}
+
+
+@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.get_existing_bom_refs")
+@patch("upload_sbom.load_sbom_components")
+@patch("upload_sbom.create_content_manifest")
+@patch("upload_sbom.get_image")
+def test_upload_sbom__success(
+    mock_get_image,
+    mock_create_content_manifest,
+    mock_load_sbom_components,
+    mock_get_existing_bom_refs,
+    mock_create_content_manifest_component,
+):
+    """
+    Basic use case - nothing exists in Pyxis yet and all components are successfully created
+    """
+    mock_get_image.return_value = IMAGE_DICT
+    mock_create_content_manifest.return_value = MANIFEST_ID
+    mock_load_sbom_components.return_value = [
+        {"bom-ref": "aaa"},
+        {"bom-ref": "bbb"},
+        {"type": "library"},
+    ]
+
+    upload_sbom(GRAPHQL_API, IMAGE_ID, SBOM_PATH)
+
+    mock_create_content_manifest.assert_called_once_with(GRAPHQL_API, IMAGE_ID)
+    mock_get_existing_bom_refs.assert_not_called()
+    assert mock_create_content_manifest_component.call_args_list == [
+        call(GRAPHQL_API, MANIFEST_ID, {"bom_ref": "aaa"}),
+        call(GRAPHQL_API, MANIFEST_ID, {"bom_ref": "bbb"}),
+        call(GRAPHQL_API, MANIFEST_ID, {"type": "library"}),
+    ]
+
+
+@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.get_existing_bom_refs")
+@patch("upload_sbom.load_sbom_components")
+@patch("upload_sbom.create_content_manifest")
+@patch("upload_sbom.get_image")
+def test_upload_sbom__manifest_and_one_component_exist(
+    mock_get_image,
+    mock_create_content_manifest,
+    mock_load_sbom_components,
+    mock_get_existing_bom_refs,
+    mock_create_content_manifest_component,
+):
+    """Creation of manifest and the first component is skipped"""
+    mock_get_image.return_value = {
+        "_id": IMAGE_ID,
+        "content_manifest": {
+            "_id": MANIFEST_ID,
+        },
+        "content_manifest_components": [{"_id": COMPONENT_ID}],
+    }
+    mock_load_sbom_components.return_value = [
+        {"bom-ref": "aaa"},
+        {"bom-ref": "bbb"},
+    ]
+    mock_get_existing_bom_refs.return_value = {"aaa"}
+
+    upload_sbom(GRAPHQL_API, IMAGE_ID, SBOM_PATH)
+
+    mock_get_existing_bom_refs.assert_called_once_with(GRAPHQL_API, MANIFEST_ID)
+    mock_create_content_manifest.assert_not_called()
+    mock_create_content_manifest_component.assert_called_once_with(
+        GRAPHQL_API, MANIFEST_ID, {"bom_ref": "bbb"}
+    )
+
+
+@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.get_existing_bom_refs")
+@patch("upload_sbom.load_sbom_components")
+@patch("upload_sbom.create_content_manifest")
+@patch("upload_sbom.get_image")
+def test_upload_sbom__all_components_exist(
+    mock_get_image,
+    mock_create_content_manifest,
+    mock_load_sbom_components,
+    mock_get_existing_bom_refs,
+    mock_create_content_manifest_component,
+):
+    """Creation of manifest and all components is skipped"""
+    mock_get_image.return_value = {
+        "_id": IMAGE_ID,
+        "content_manifest": {
+            "_id": MANIFEST_ID,
+        },
+        "content_manifest_components": [{"_id": COMPONENT_ID}, {"_id": "123"}],
+    }
+    mock_load_sbom_components.return_value = [
+        {"bom-ref": "aaa"},
+        {"bom-ref": "bbb"},
+    ]
+
+    upload_sbom(GRAPHQL_API, IMAGE_ID, SBOM_PATH)
+
+    mock_get_existing_bom_refs.assert_not_called()
+    mock_create_content_manifest.assert_not_called()
+    mock_create_content_manifest_component.assert_not_called()
+
+
+def generate_pyxis_response(query_name, data=None, error=False):
+    response = {
+        "data": {
+            query_name: {
+                "data": data,
+                "error": None,
+            }
+        }
+    }
+    if error:
+        response["data"][query_name]["error"] = {"detail": "Major failure!"}
+    return response
+
+
+@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.get_existing_bom_refs")
+@patch("upload_sbom.load_sbom_components")
+@patch("upload_sbom.create_content_manifest")
+@patch("upload_sbom.get_image")
+def test_upload_sbom__existing_bom_ref_is_skipped(
+    mock_get_image,
+    mock_create_content_manifest,
+    mock_load_sbom_components,
+    mock_get_existing_bom_refs,
+    mock_create_content_manifest_component,
+):
+    """One component already exists in Pyxis. Our sbom contains two
+    components. So we want to upload only the second one to Pyxis,
+    but we notice that bom-ref already exists in Pyxis for this image,
+    so we skip it.
+    """
+    mock_get_image.return_value = {
+        "_id": IMAGE_ID,
+        "content_manifest": {
+            "_id": MANIFEST_ID,
+        },
+        "content_manifest_components": [{"_id": COMPONENT_ID}],
+    }
+    mock_load_sbom_components.return_value = [
+        {"bom-ref": "bbb"},
+        {"bom-ref": "aaa"},
+    ]
+    mock_get_existing_bom_refs.return_value = {"aaa"}
+
+    upload_sbom(GRAPHQL_API, IMAGE_ID, SBOM_PATH)
+
+    mock_get_existing_bom_refs.assert_called_once_with(GRAPHQL_API, MANIFEST_ID)
+    mock_create_content_manifest.assert_not_called()
+    mock_create_content_manifest_component.assert_not_called()
+
+
+@patch("pyxis.post")
+def test_get_image__success(mock_post):
+    mock_post.return_value = generate_pyxis_response("get_image", IMAGE_DICT)
+
+    image = get_image(GRAPHQL_API, IMAGE_ID)
+
+    assert image == IMAGE_DICT
+    mock_post.assert_called_once()
+
+
+@patch("pyxis.post")
+def test_get_image__error(mock_post):
+    mock_post.return_value = generate_pyxis_response("get_image", error=True)
+
+    with pytest.raises(RuntimeError):
+        get_image(GRAPHQL_API, IMAGE_ID)
+
+    mock_post.assert_called_once()
+
+
+@patch("pyxis.post")
+def test_create_content_manifest__success(mock_post):
+    mock_post.return_value = generate_pyxis_response(
+        "create_content_manifest", {"_id": MANIFEST_ID}
+    )
+
+    id = create_content_manifest(GRAPHQL_API, IMAGE_ID)
+
+    assert id == MANIFEST_ID
+    mock_post.assert_called_once()
+
+
+@patch("pyxis.post")
+def test_create_content_manifest__error(mock_post):
+    mock_post.return_value = generate_pyxis_response("create_content_manifest", error=True)
+
+    with pytest.raises(RuntimeError):
+        create_content_manifest(GRAPHQL_API, IMAGE_ID)
+
+    mock_post.assert_called_once()
+
+
+@patch("pyxis.post")
+def test_get_existing_components__success(mock_post):
+    """The Pyxis query is called twice and then the loop stops"""
+    data1 = ["a", "b"]
+    data2 = ["c"]
+    mock_post.side_effect = [
+        generate_pyxis_response("find_content_manifest_components", data1),
+        generate_pyxis_response("find_content_manifest_components", data2),
+    ]
+
+    components = get_existing_components(GRAPHQL_API, MANIFEST_ID, page_size=2)
+
+    assert components == data1 + data2
+    assert mock_post.call_count == 2
+
+
+@patch("pyxis.post")
+def test_get_existing_components__no_components(mock_post):
+    """Pyxis returns an empty list, so the loop stops and returns that"""
+    mock_post.return_value = generate_pyxis_response("find_content_manifest_components", [])
+
+    components = get_existing_components(GRAPHQL_API, MANIFEST_ID)
+
+    assert components == []
+    mock_post.assert_called_once()
+
+
+@patch("pyxis.post")
+def test_get_existing_components__error(mock_post):
+    """Pyxis returns an error"""
+    mock_post.return_value = generate_pyxis_response(
+        "find_content_manifest_components", error=True
+    )
+
+    with pytest.raises(RuntimeError):
+        get_existing_components(GRAPHQL_API, MANIFEST_ID)
+
+    mock_post.assert_called_once()
+
+
+@patch("upload_sbom.get_existing_components")
+def test_get_existing_bom_refs__success(mock_get_existing_components):
+    """bom_refs are correctly extracted from components, duplicates are removed"""
+    mock_get_existing_components.return_value = [
+        {"bom_ref": "a"},
+        {"bom_ref": "b"},
+        {"bom_ref": "c"},
+        {"bom_ref": "a"},
+    ]
+
+    bom_refs = get_existing_bom_refs(GRAPHQL_API, MANIFEST_ID)
+
+    assert bom_refs == {"a", "b", "c"}
+
+
+@patch("upload_sbom.get_existing_components")
+def test_get_existing_bom_refs__no_components_result_in_empty_set(
+    mock_get_existing_components,
+):
+    mock_get_existing_components.return_value = []
+
+    bom_refs = get_existing_bom_refs(GRAPHQL_API, MANIFEST_ID)
+
+    assert bom_refs == set()
+
+
+@patch("pyxis.post")
+def test_create_content_manifest_component__success(mock_post):
+    mock_post.return_value = generate_pyxis_response(
+        "create_content_manifest_component_for_manifest", {"_id": COMPONENT_ID}
+    )
+
+    id = create_content_manifest_component(GRAPHQL_API, MANIFEST_ID, COMPONENT_DICT)
+
+    assert id == COMPONENT_ID
+    mock_post.assert_called_once()
+
+
+@patch("pyxis.post")
+def test_create_content_manifest_component__error(mock_post):
+    mock_post.return_value = generate_pyxis_response(
+        "create_content_manifest_component_for_manifest", error=True
+    )
+
+    with pytest.raises(RuntimeError):
+        create_content_manifest_component(GRAPHQL_API, MANIFEST_ID, COMPONENT_DICT)
+
+    mock_post.assert_called_once()
+
+
+def test_get_existing_component_count__some_components():
+    image = {
+        "content_manifest_components": [
+            COMPONENT_DICT,
+            COMPONENT_DICT,
+        ]
+    }
+
+    count = get_existing_component_count(image)
+
+    assert count == 2
+
+
+def test_get_existing_component_count__no_components():
+    image = {}
+
+    count = get_existing_component_count(image)
+
+    assert count == 0
+
+
+@patch("json.load")
+@patch("upload_sbom.check_bom_ref_duplicates")
+@patch("builtins.open")
+def test_load_sbom_components__success(mock_open, mock_check_bom_ref_duplicates, mock_load):
+    fake_components = [1, 2, 3, 4]
+    mock_load.return_value = {"components": fake_components}
+
+    loaded_components = load_sbom_components(SBOM_PATH)
+
+    mock_load.assert_called_once_with(mock_open.return_value.__enter__.return_value)
+    mock_check_bom_ref_duplicates.assert_called_once_with(loaded_components)
+    assert fake_components == loaded_components
+
+
+@patch("json.load")
+@patch("upload_sbom.check_bom_ref_duplicates")
+@patch("builtins.open")
+def test_load_sbom_components__json_load_fails(
+    mock_open, mock_check_bom_ref_duplicates, mock_load
+):
+    mock_load.side_effect = ValueError
+
+    with pytest.raises(ValueError):
+        load_sbom_components(SBOM_PATH)
+
+    mock_load.assert_called_once_with(mock_open.return_value.__enter__.return_value)
+    mock_check_bom_ref_duplicates.assert_not_called()
+
+
+def test_check_bom_ref_duplicates__no_duplicates():
+    components = [
+        {"bom-ref": "a"},
+        {"bom-ref": "b"},
+        {},
+        {"bom-ref": "c"},
+    ]
+
+    check_bom_ref_duplicates(components)
+
+
+def test_check_bom_ref_duplicates__duplicates_found():
+    components = [
+        {"bom-ref": "a"},
+        {"bom-ref": "b"},
+        {},
+        {"bom-ref": "a"},
+    ]
+
+    with pytest.raises(ValueError):
+        check_bom_ref_duplicates(components)
+
+
+def test_convert_keys__success():
+    external_references = [
+        {"url": "myurl1"},
+        {"url": "myurl2"},
+    ]
+    input = {
+        "bom-ref": "mybomref",
+        "externalReferences": external_references,
+        "releaseNotes": {"featuredImage": "myimage"},
+    }
+    expected_output = {
+        "bom_ref": "mybomref",
+        "external_references": external_references,
+        "release_notes": {"featured_image": "myimage"},
+    }
+
+    output = convert_keys(input)
+
+    assert output == expected_output
+
+
+def test_remove_unsupported_fields__success():
+    component_orig = {
+        "a": "aa",
+        "b": "bb",
+    }
+    component_new = component_orig.copy()
+    component_new[UNSUPPORTED_FIELDS[0]] = "mystr"
+
+    remove_unsupported_fields(component_new)
+
+    assert component_new == component_orig

--- a/pyxis/test_upload_sbom.py
+++ b/pyxis/test_upload_sbom.py
@@ -71,7 +71,7 @@ def test_upload_sbom__manifest_and_one_component_exist(
     mock_get_existing_bom_refs,
     mock_create_content_manifest_component,
 ):
-    """Creation of manifest and the first component is skipped"""
+    """Creation of both the manifest and the first component is skipped"""
     mock_get_image.return_value = {
         "_id": IMAGE_ID,
         "content_manifest": {
@@ -266,6 +266,7 @@ def test_get_existing_bom_refs__success(mock_get_existing_components):
         {"bom_ref": "a"},
         {"bom_ref": "b"},
         {"bom_ref": "c"},
+        {},  # Component with no bom_ref
         {"bom_ref": "a"},
     ]
 
@@ -323,7 +324,9 @@ def test_get_existing_component_count__some_components():
 
 
 def test_get_existing_component_count__no_components():
-    image = {}
+    image = {
+        "_id": IMAGE_ID,
+    }
 
     count = get_existing_component_count(image)
 

--- a/pyxis/upload_sbom.py
+++ b/pyxis/upload_sbom.py
@@ -286,10 +286,19 @@ def load_sbom_components(sbom_path: str) -> list[dict]:
         LOGGER.error("Unable to load components from sbom file")
         raise
 
-    # bom-ref is not required, but has to be unique for
-    # a given sbom. In most cases it is defined.
-    # Pyxis team suggested we at least check this,
-    # since Pyxis has no checks for component uniqueness.
+    check_bom_ref_duplicates(components)
+
+    return components
+
+
+def check_bom_ref_duplicates(components: list[dict]):
+    """Check if any two components use the same bom-ref string
+
+    bom-ref is not required, but has to be unique for
+    a given sbom. In most cases it is defined.
+    Pyxis team suggested we at least check this,
+    since Pyxis has no checks for component uniqueness.
+    """
     bom_refs = [c["bom-ref"] for c in components if c.get("bom-ref") is not None]
     seen = set()
     for x in bom_refs:
@@ -300,8 +309,6 @@ def load_sbom_components(sbom_path: str) -> list[dict]:
             raise ValueError(msg)
         else:
             seen.add(x)
-
-    return components
 
 
 def convert_keys(item: Any) -> Any:

--- a/pyxis/upload_sbom.py
+++ b/pyxis/upload_sbom.py
@@ -40,7 +40,7 @@ UNSUPPORTED_FIELDS = [
 ]
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments() -> argparse.Namespace:  # pragma: no cover
     """Parse CLI arguments
 
     :return: Dictionary of parsed arguments

--- a/pyxis/upload_sbom.py
+++ b/pyxis/upload_sbom.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Upload sbom to Pyxis
+
+This script will take Pyxis image ID and an sbom cyclonedx file
+on the input and it will push the sbom data into Pyxis.
+This consists of two steps:
+1. Create a ContentManifest in Pyxis, referencing the image ID provided
+   If a manifest already exists, creation is skipped.
+2. For each sbom component, create a ContentManifestComponent in Pyxis,
+   referencing the ContentManifest created in step 1. above.
+   If some components already exists, their creation is skipped.
+
+Required env vars:
+PYXIS_KEY_PATH
+PYXIS_CERT_PATH
+
+Optional env vars:
+PYXIS_GRAPHQL_API
+"""
+import argparse
+import logging
+import string
+import os
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pyxis
+
+LOGGER = logging.getLogger("upload_sbom")
+
+
+# Fields not implemented in Pyxis
+# See https://issues.redhat.com/browse/ISV-3376
+UNSUPPORTED_FIELDS = [
+    "pedigree",
+    "signature",
+    "components",
+]
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse CLI arguments
+
+    :return: Dictionary of parsed arguments
+    """
+
+    parser = argparse.ArgumentParser(description="Upload sbom metadata to Pyxis")
+
+    parser.add_argument(
+        "--pyxis-graphql-api",
+        default=os.environ.get("PYXIS_GRAPHQL_API", "https://graphql-pyxis.api.redhat.com/"),
+        help="Pyxis Graphql endpoint.",
+    )
+    parser.add_argument(
+        "--image-id",
+        help="Pyxis container image ID. If omitted, sbom filename is used",
+    )
+    parser.add_argument("--sbom-path", help="Path to the sbom file", required=True)
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    return parser.parse_args()
+
+
+def upload_sbom(graphql_api: str, image_id: str, sbom_path: str):
+    image = get_image(graphql_api, image_id)
+    LOGGER.debug(f"Image response: {image}")
+
+    if "content_manifest" in image and "_id" in image["content_manifest"]:
+        content_manifest_id = image["content_manifest"]["_id"]
+        LOGGER.info("Content manifest already exists. Skipping creation.")
+    else:
+        content_manifest_id = create_content_manifest(graphql_api, image_id)
+    LOGGER.info(f"Content manifest ID: {content_manifest_id}")
+
+    existing_component_count = get_existing_component_count(image)
+
+    sbom_components = load_sbom_components(sbom_path)
+    sbom_component_count = len(sbom_components)
+    LOGGER.info(f"Loaded {sbom_component_count} components from sbom file.")
+
+    if existing_component_count >= sbom_component_count:
+        LOGGER.info(
+            f"Pyxis already contains {existing_component_count} components."
+            " Skipping component creation."
+        )
+        return
+
+    if existing_component_count > 0:
+        existing_bom_refs = get_existing_bom_refs(graphql_api, content_manifest_id)
+        LOGGER.info(
+            f"Skipping {existing_component_count} components already present in Pyxis."
+        )
+    else:
+        existing_bom_refs = set()
+
+    for i in range(existing_component_count, sbom_component_count):
+        component = sbom_components[i]
+        component = convert_keys(component)
+        remove_unsupported_fields(component)
+
+        LOGGER.info(f"Processing component {i+1}/{sbom_component_count}")
+
+        # bom-ref is not required, but has to be unique for
+        # a given sbom. In most cases it is defined.
+        # Pyxis team suggested we at least check this,
+        # since Pyxis has no checks for component uniqueness.
+        if component.get("bom_ref") is not None:
+            if component["bom_ref"] in existing_bom_refs:
+                LOGGER.info("Skipping component - bom_ref already exists in Pyxis")
+                continue
+            else:
+                existing_bom_refs.add(component["bom_ref"])
+
+        component_id = create_content_manifest_component(
+            graphql_api, content_manifest_id, component
+        )
+        if component_id is not None:
+            LOGGER.info(f"Component ID: {component_id}")
+
+
+def get_image(graphql_api: str, image_id: str) -> dict:
+    query = """
+query ($id: ObjectIDFilterScalar!) {
+    get_image(id: $id) {
+        data {
+            _id
+            content_manifest {
+                _id
+            }
+            content_manifest_components {
+                _id
+            }
+        }
+        error {
+            detail
+        }
+    }
+}
+    """
+    variables = {"id": image_id}
+    body = {"query": query, "variables": variables}
+
+    resp = pyxis.post(graphql_api, body)
+    resp = resp["data"]["get_image"]
+    if resp["error"] is not None:
+        LOGGER.error(f"Unable to get image from Pyxis: {resp['error']['detail']}")
+        raise RuntimeError("Unable to get image from Pyxis")
+
+    return resp["data"]
+
+
+def create_content_manifest(graphql_api: str, image_id: str) -> str:
+    """Create ContentManifest object in Pyxis using GraphQL API"""
+    mutation = """
+mutation ($input: ContentManifestInput! ) {
+    create_content_manifest(input: $input) {
+        data {
+            _id
+        }
+        error {
+            detail
+        }
+    }
+}
+"""
+    variables = {"input": {"image": {"_id": image_id}}}
+    body = {"query": mutation, "variables": variables}
+
+    resp = pyxis.post(graphql_api, body)
+    resp = resp["data"]["create_content_manifest"]
+    if resp["error"] is not None:
+        LOGGER.error(
+            f"Creation of Content Manifest resulted in an error: {resp['error']['detail']}"
+        )
+        raise RuntimeError("Error when creating Content Manifest in Pyxis")
+
+    return resp["data"]["_id"]
+
+
+def get_existing_components(graphql_api: str, content_manifest_id: str, page_size: int = 50):
+    """Get ContentManifestComponent objects from Pyxis using GraphQL API"""
+    query = """
+query ($input: ObjectIDFilterScalar!, $page: Int!, $page_size: Int!) {
+  find_content_manifest_components(
+        page: $page,
+        page_size: $page_size,
+        sort_by: [],
+        filter: {content_manifest: { _id: {eq: $input}}}
+  ) {
+    error {
+      detail
+      status
+    }
+
+    page_size
+    page
+
+    data {
+      _id
+      bom_ref
+    }
+  }
+}
+"""
+    has_more = True
+    page = 0
+    components = []
+    while has_more:
+        variables = {"input": content_manifest_id, "page": page, "page_size": page_size}
+        body = {"query": query, "variables": variables}
+
+        resp = pyxis.post(graphql_api, body)
+        resp = resp["data"]["find_content_manifest_components"]
+        if resp["error"] is not None:
+            LOGGER.error(
+                f"Creation of Content Manifest resulted in an error: {resp['error']['detail']}"
+            )
+            raise RuntimeError("Error when creating Content Manifest in Pyxis")
+        LOGGER.info(f"Adding: {resp['data']}")
+        components.extend(resp["data"])
+        has_more = len(resp["data"]) == page_size
+        page += 1
+    LOGGER.debug(f"Existing components ({len(components)}):")
+    LOGGER.debug(components)
+    return components
+
+
+def get_existing_bom_refs(graphql_api: str, content_manifest_id: str) -> set[str]:
+    components = get_existing_components(graphql_api, content_manifest_id)
+    bom_refs = [c["bom_ref"] for c in components if c.get("bom_ref") is not None]
+    return set(bom_refs)
+
+
+def create_content_manifest_component(
+    graphql_api: str, content_manifest_id: str, component: dict
+) -> str:
+    """Create ContentManifestComponent object in Pyxis using GraphQL API"""
+    mutation = """
+mutation ($id: ObjectIDFilterScalar!, $input: ContentManifestComponentInput! ) {
+    create_content_manifest_component_for_manifest(id: $id, input: $input) {
+        data {
+            _id
+        }
+        error {
+            detail
+        }
+    }
+}
+"""
+    variables = {"id": content_manifest_id, "input": component}
+    body = {"query": mutation, "variables": variables}
+
+    resp = pyxis.post(graphql_api, body)
+
+    resp = resp["data"]["create_content_manifest_component_for_manifest"]
+    if resp["error"] is not None:
+        LOGGER.error(
+            "Creation of Content Manifest Component resulted in an error:"
+            f" {resp['error']['detail']}"
+        )
+        raise RuntimeError("Error when creating Content Manifest Component in Pyxis")
+
+    return resp["data"]["_id"]
+
+
+def get_existing_component_count(image: dict) -> int:
+    if "content_manifest_components" in image:
+        return len(image["content_manifest_components"])
+    else:
+        return 0
+
+
+def load_sbom_components(sbom_path: str) -> list[dict]:
+    """Open sbom file, load components and return them
+
+    If unable to open and load the json, raise an exception.
+    If there are duplicate bom-ref strings in the components,
+    raise an exception.
+    """
+    try:
+        with open(sbom_path) as f:
+            sbom = json.load(f)
+        components = sbom["components"]
+    except Exception:
+        LOGGER.error("Unable to load components from sbom file")
+        raise
+
+    # bom-ref is not required, but has to be unique for
+    # a given sbom. In most cases it is defined.
+    # Pyxis team suggested we at least check this,
+    # since Pyxis has no checks for component uniqueness.
+    bom_refs = [c["bom-ref"] for c in components if c.get("bom-ref") is not None]
+    seen = set()
+    for x in bom_refs:
+        if x in seen:
+            LOGGER.error(f"Duplicate bom-ref detected: {x}")
+            msg = "Invalid sbom file. bom-ref must to be unique."
+            LOGGER.error(msg)
+            raise ValueError(msg)
+        else:
+            seen.add(x)
+
+    return components
+
+
+def convert_keys(item: Any) -> Any:
+    """Transform component keys to what's used in Pyxis
+
+    Some of the CycloneDX component field names use characters that are not allowed
+    as field names in Pyxis (GraphQL). Namely these two conversions are made recursively:
+    1. Use _ instead of camel case, e.g. camelCase -> camel_case
+    2. Use _ instead of -, e.g. key-with-dash -> key_with_dash
+    """
+    if isinstance(item, list):
+        return [convert_keys(sub) for sub in item]
+    elif isinstance(item, dict):
+        d = {}
+        for k, v in item.items():
+            k = k.replace("-", "_")
+            k = re.sub("([A-Z]+)", r"_\1", k).lower()
+            d[k] = convert_keys(v)
+        return d
+    else:
+        return item
+
+
+def remove_unsupported_fields(component: dict):
+    """Remove component fields that are not supported in Pyxis"""
+    for key in UNSUPPORTED_FIELDS:
+        if key in component:
+            del component[key]
+
+
+def main():  # pragma: no cover
+    """Main func"""
+    args = parse_arguments()
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    pyxis.setup_logger(level=log_level)
+
+    if not os.path.isfile(args.sbom_path):
+        msg = f"sbom file does not exist: {args.sbom_path}"
+        LOGGER.error(msg)
+        raise RuntimeError(msg)
+
+    # Use sbom filename (minus extension) for image_id if not provided
+    if args.image_id is None:
+        image_id = Path(args.sbom_path).stem
+    else:
+        image_id = args.image_id
+    if not all(c in string.hexdigits for c in image_id):
+        raise ValueError(f"image-id is invalid, hexadecimal value is expected: {image_id}")
+    LOGGER.debug(f"Image ID: {image_id}")
+
+    LOGGER.debug(f"Pyxis GraphQL API: {args.pyxis_graphql_api}")
+
+    upload_sbom(args.pyxis_graphql_api, args.image_id, args.sbom_path)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
This script will push sbom data to Pyxis.

The script is ready for review. Unit tests will be added once first iteration of review is done to avoid wasting time in case significant refactoring comes out of the review.

For input, you'll need a Pyxis image id and an sbom. For how to get an sbom for an image url, see here: https://github.com/hacbs-release/release-bundles/pull/92
You'll need cosign:
- How to install: https://docs.sigstore.dev/cosign/installation/
- And then run something like: `cosign download sbom --output-file my-sbom.json $IMAGE_URL`

Then run the script, e.g.:
```
$ ./pyxis/upload_sbom.py --pyxis-graphql-api https://graphql.pyxis.qa.engineering.redhat.com/graphql/ --image-id 64020cafb94be12a048de276 --sbom-path ~/tmp/sbom/sbom-cyclonedx.json
```
