### PR TITLE
chore(HACBS-1614): release-utils repo rename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN rpm -ivh https://github.com/sigstore/cosign/releases/download/v${COSIGNVERSI
 ENV HOME=/tekton/home
 
 # The ~ dir seems to be mounted over in tekton tasks, so put in /home
-RUN git clone https://github.com/hacbs-release/release-utils /home/release-utils
+RUN git clone https://github.com/redhat-appstudio/release-service-utils /home/release-service-utils
 
-# Copy the create_container_image script so we can use it without extension in release-bundles
-RUN cp /home/release-utils/pyxis/create_container_image.py /home/release-utils/pyxis/create_container_image
+# Copy the create_container_image script so we can use it without extension in release-service-bundles
+RUN cp /home/release-service-utils/pyxis/create_container_image.py /home/release-service-utils/pyxis/create_container_image
 
-ENV PATH=$PATH:/home/release-utils/pyxis
+ENV PATH=$PATH:/home/release-service-utils/pyxis

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# release-utils
+# release-service-utils

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -179,7 +179,7 @@ def test_prepare_parsed_data():
         "Digest": "sha:abc",
         "DockerVersion": "1",
         "Layers": ["1", "2"],
-        "Name": "quay.io/hacbs-release/release-utils",
+        "Name": "quay.io/hacbs-release/release-service-utils",
         "Architecture": "test",
         "Env": ["a=test"],
     }
@@ -194,5 +194,5 @@ def test_prepare_parsed_data():
         "docker_version": "1",
         "env_variables": ["a=test"],
         "layers": ["1", "2"],
-        "name": "quay.io/hacbs-release/release-utils",
+        "name": "quay.io/hacbs-release/release-service-utils",
     }


### PR DESCRIPTION
The release-utils repo was moved from hacbs-release/release-utils to redhat-appstudio/release-service-utils. This commit changes the references in this repo.