### PR TITLE
fix(HACBS-1553): bugs in upload sbom script

### DIFF
--- a/pyxis/test_upload_sbom.py
+++ b/pyxis/test_upload_sbom.py
@@ -21,7 +21,11 @@ IMAGE_ID = "123456abcd"
 SBOM_PATH = "mypath"
 MANIFEST_ID = "abcd1234"
 COMPONENT_ID = "abcd2222"
-IMAGE_DICT = {"_id": IMAGE_ID}
+IMAGE_DICT = {
+    "_id": IMAGE_ID,
+    "content_manifest": None,
+    "content_manifest_components": None,
+}
 COMPONENT_DICT = {"bom_ref": "mybomref"}
 
 
@@ -326,6 +330,7 @@ def test_get_existing_component_count__some_components():
 def test_get_existing_component_count__no_components():
     image = {
         "_id": IMAGE_ID,
+        "content_manifest_components": None,
     }
 
     count = get_existing_component_count(image)


### PR DESCRIPTION
image_id was None if taken from sbom filename.
It was calculated properly, but then the wrong
variable was used.

Check for existing content_manifest and
content_manifest_components in image was wrong.
The old code worked when REST api was used, but
since I switched to GraphQL, the properties will
always exist and be None if no objects are found.

Also, split out graphql queries into a new function. This includes improved error handling.
Before this change, in some testing I was
getting unhelpful error messages when the request
failed on a lower level (e.g. wrong query parameter).