### PR TITLE
fix: remove fetching of unreachable CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,6 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     skopeo \
     && dnf clean all
 
-# Adds Red Hat IT Root CAs
-ADD https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem /etc/pki/ca-trust/source/anchors/
-RUN update-ca-trust
-
 COPY pyxis /home/pyxis
 COPY utils /home/utils
 


### PR DESCRIPTION
Red Hat IT Root CA is unreachable from actions so this PR removes the fetching
of it to unblock image builds until we find a permanent solution.