### PR TITLE
feat(HACBS-2271): improve reliability of upload_sbom script

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -145,7 +145,7 @@ def create_container_image(args, parsed_data: Dict[str, Any]):
             }
         )
 
-    rsp = pyxis.post(upload_url, container_image_payload)
+    rsp = pyxis.post(upload_url, container_image_payload).json()
 
     # Make sure container metadata was successfully added to Pyxis
     if "_id" in rsp:

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -48,7 +48,7 @@ def test_image_already_exists(mock_get: MagicMock):
 @patch("create_container_image.datetime")
 def test_create_container_image(mock_datetime: MagicMock, mock_post: MagicMock):
     # Mock an _id in the response for logger check
-    mock_post.return_value = {"_id": 0}
+    mock_post.return_value.json.return_value = {"_id": 0}
 
     # mock date
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
@@ -95,7 +95,7 @@ def test_create_container_image(mock_datetime: MagicMock, mock_post: MagicMock):
 @patch("create_container_image.datetime")
 def test_create_container_image_latest(mock_datetime: MagicMock, mock_post: MagicMock):
     # Mock an _id in the response for logger check
-    mock_post.return_value = {"_id": 0}
+    mock_post.return_value.json.return_value = {"_id": 0}
 
     # mock date
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))

--- a/pyxis/test_pyxis.py
+++ b/pyxis/test_pyxis.py
@@ -41,10 +41,9 @@ def test_get_session_no_auth(monkeypatch: Any) -> None:
 
 @patch("pyxis._get_session")
 def test_post(mock_session: MagicMock) -> None:
-    mock_session.return_value.post.return_value.json.return_value = {"key": "val"}
     resp = pyxis.post(API_URL, {})
 
-    assert resp == {"key": "val"}
+    assert resp == mock_session.return_value.post.return_value
 
 
 @patch("pyxis._get_session")
@@ -63,7 +62,7 @@ def test_graphql_query__success(mock_post: MagicMock):
     mock_data = {
         "output": "something",
     }
-    mock_post.return_value = {
+    mock_post.return_value.json.return_value = {
         "data": {
             QUERY: {
                 "data": mock_data,
@@ -82,7 +81,10 @@ def test_graphql_query__success(mock_post: MagicMock):
 def test_graphql_query__general_graphql_error(mock_post: MagicMock):
     """For example, if there is a syntax error in the query,
     the response won't even include the query property"""
-    mock_post.return_value = {"data": None, "errors": [{"message": "Major failure"}]}
+    mock_post.return_value.json.return_value = {
+        "data": None,
+        "errors": [{"message": "Major failure"}],
+    }
 
     with pytest.raises(RuntimeError):
         pyxis.graphql_query(API_URL, REQUEST_BODY, QUERY)
@@ -94,7 +96,7 @@ def test_graphql_query__general_graphql_error(mock_post: MagicMock):
 def test_graphql_query__pyxis_error(mock_post: MagicMock):
     """For example, if the image id does not exist in Pyxis
     there will be an error property under the query property"""
-    mock_post.return_value = {
+    mock_post.return_value.json.return_value = {
         "data": {
             QUERY: {
                 "data": None,

--- a/pyxis/test_upload_sbom.py
+++ b/pyxis/test_upload_sbom.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, call
+from unittest.mock import patch, call, Mock
 
 from upload_sbom import (
     upload_sbom,
@@ -124,7 +124,7 @@ def test_upload_sbom__all_components_exist(
 
 
 def generate_pyxis_response(query_name, data=None, error=False):
-    response = {
+    response_json = {
         "data": {
             query_name: {
                 "data": data,
@@ -133,7 +133,10 @@ def generate_pyxis_response(query_name, data=None, error=False):
         }
     }
     if error:
-        response["data"][query_name]["error"] = {"detail": "Major failure!"}
+        response_json["data"][query_name]["error"] = {"detail": "Major failure!"}
+    response = Mock()
+    response.json.return_value = response_json
+
     return response
 
 


### PR DESCRIPTION
This PR adds two improvements:

1. Print pyxis trace_id on graphql failure - this will help with debugging if the Pyxis request fails
2. Add retry option for upload_sbom script - this option will be used in the Tekton task and it will improve the reliability of the pipeline