### PR TITLE
chore: use git shallow clone

### DIFF
--- a/utils/git-functions
+++ b/utils/git-functions
@@ -68,7 +68,7 @@ git_clone_and_checkout() {
 
     # rewrites the repo url with the auth token
     CLONE_URL="https://oauth2:${ACCESS_TOKEN}@${REPOSITORY#*://}"
-    git clone $CLONE_URL
+    git clone --depth 1 $CLONE_URL
     cd $REPO_DIR
     git checkout $REVISION
 }


### PR DESCRIPTION
Use git shallow clone to save disk space and clone time.