### PR TITLE
feat(HACBS-2405): add a setup script for tekton task testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN update-ca-trust
 
 COPY pyxis /home/pyxis
 COPY utils /home/utils
+COPY tekton /home/tekton
 
 # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
 ENV HOME=/tekton/home
-ENV PATH="$PATH:/home/pyxis:/home/utils"
+ENV PATH="$PATH:/home/pyxis:/home/utils:/home/tekton"

--- a/tekton/test-push-sbom-to-pyxis
+++ b/tekton/test-push-sbom-to-pyxis
@@ -1,0 +1,24 @@
+# Description: This script is meant to set up mocks at the beginning
+#              of each step of the push-sbom-to-pyxis task.
+
+function cosign() {
+  echo Mock cosign called with: $*
+
+  if [[ "$*" != "download sbom --output-file myImageID"[12]".json imageurl"[12] ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+
+  touch /workdir/sboms/${4}
+}
+
+function upload_sbom() {
+  echo Mock upload_sbom called with: $*
+
+  if [[ "$*" != "--retry --sbom-path "*".json" ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+}

--- a/tekton/test-push-sbom-to-pyxis-no-snapshot
+++ b/tekton/test-push-sbom-to-pyxis-no-snapshot
@@ -1,0 +1,16 @@
+# Description: This script is meant to set up mocks at the beginning
+#              of each step of the push-sbom-to-pyxis task.
+
+function cosign() {
+  echo Mock cosign called with: $*
+
+  echo Error: cosign should not be called
+  exit 1
+}
+
+function upload_sbom() {
+  echo Mock upload_sbom called with: $*
+
+  echo Error: upload_sbom should not be called
+  exit 1
+}

--- a/tekton/test-push-sbom-to-pyxis-urls-ids-mismatch
+++ b/tekton/test-push-sbom-to-pyxis-urls-ids-mismatch
@@ -1,0 +1,16 @@
+# Description: This script is meant to set up mocks at the beginning
+#              of each step of the push-sbom-to-pyxis task.
+
+function cosign() {
+  echo Mock cosign called with: $*
+
+  echo Error: cosign should not be called
+  exit 1
+}
+
+function upload_sbom() {
+  echo Mock upload_sbom called with: $*
+
+  echo Error: upload_sbom should not be called
+  exit 1
+}


### PR DESCRIPTION
The new tekton dir will be used for storing init scripts for tekton task testing in the release-service-bundles repo.

This change is needed by
https://github.com/redhat-appstudio/release-service-bundles/pull/159