### PR TITLE
feat(HACBS-2506): add linting for commit messages

### DIFF
--- a/.github/gitlint/contrib_format_conventional_commits.py
+++ b/.github/gitlint/contrib_format_conventional_commits.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from gitlint.rules import CommitRule, RuleViolation
+import re
+
+
+class ConventionalCommitsFormat(CommitRule):
+    """This rule will enforce that each commit title follows the
+    conventional commit prefix standards and the commit
+    description starts with a lowercase character."""
+
+    id = "UC1"
+    name = "contrib-format-conventional-commits"
+
+    def validate(self, commit):
+        """Validate the given commit checking that the title has a
+        proper prefix and the description starts with a lowercase."""
+
+        regex_string = r"^(chore|docs|feat|fix|refactor|revert|style|test)(\(.*\))?: [a-z].*$"
+        pattern = re.compile(regex_string)
+        if not pattern.match(commit.message.title):
+            return [
+                RuleViolation(
+                    self.id, f"Commit title doesn't follow the spec {regex_string}", line_nr=1
+                )
+            ]

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,14 @@
+[general]
+contrib=contrib-title-conventional-commits,CC1
+extra-path=.github/gitlint
+ignore=T5
+
+[title-max-length]
+line-length=72
+
+[body-max-line-length]
+line-length=72
+
+[body-first-line-empty]
+
+[contrib-title-conventional-commits]


### PR DESCRIPTION
Adds linting for commit messages including "revert" prefix support