### PR TITLE
feat(HACBS-2590): adds new parameters to gitlab_create_mr

### DIFF
--- a/utils/gitlab-functions
+++ b/utils/gitlab-functions
@@ -17,13 +17,21 @@ gitlab_auth() {
 }
 
 gitlab_create_mr() {
-    OPTIONS=$(getopt -l "head:,title:,description:" -o "h:t:d:" -a -- "$@")
+    OPTIONS=$(getopt -l "head:,title:,target-branch:,description:,upstream-repo:" -o "h:t:b:d:u:" -a -- "$@")
     eval set -- "$OPTIONS"
     while true; do
         case "$1" in
             -h|--head)
                 shift
                 HEAD="$1";
+                ;;
+            -u|--upstream-repo)
+                shift
+                UPSTREAM_REPO="$1";
+                ;;
+            -b|--target-branch)
+                shift
+                TARGET_BRANCH="$1";
                 ;;
             -t|--title)
                 shift
@@ -40,7 +48,9 @@ gitlab_create_mr() {
         esac
         shift
     done
-    glab mr create --title "${TITLE}" -b ${HEAD} --description "${DESCRIPTION}" | \
+    git remote add glab-base "${UPSTREAM_REPO}"
+    glab mr create --title "${TITLE}" --source-branch ${HEAD} --target-branch ${TARGET_BRANCH} \
+        --description "${DESCRIPTION}" -R "${UPSTREAM_REPO}" | \
         awk '/merge_request/ {print "merge_request: "$1}' |yq -o json
 }
 


### PR DESCRIPTION
This PR adds the new parameters `--upstream-repo` and `--target-branch` to the `gitlab_create_mr` function.
Signed-off-by: Leandro Mendes <lmendes@redhat.com>