### PR TITLE
chore: adds diffutils to the utils image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     git \
     jq \
     python39-devel \
+    diffutils \
     python39-requests \
     skopeo \
     krb5-workstation \


### PR DESCRIPTION
This PR adds the `diff` command to the release-utils-image to allow the task `process-file-updates` so it can compare (per replace expression) what was changed, so in case of wrong replacement the requester can see exactly what was done wrong.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>