### PR TITLE
fix: merge-json doesn't merge properly

### DIFF
--- a/utils/merge-json
+++ b/utils/merge-json
@@ -43,7 +43,7 @@ if ! echo "$json2" | jq -e . >/dev/null 2>&1; then
 fi
 
 # Merge the JSON objects
-merged_json=$(printf '%s\n%s' "$json1" "$json2" | jq -cs add)
+merged_json=$(printf '%s\n%s' "$json1" "$json2" | jq -cs '.[0] * .[1]')
 
 # Print the merged JSON
 echo "$merged_json"


### PR DESCRIPTION
```
[jbieren@jbieren utils]$ echo $json1
{"data":{"foo":"bar"}}
[jbieren@jbieren utils]$ echo $json2
{"data":{"one":"two"}}
[jbieren@jbieren utils]$ echo $json3
{"data":{"one":"three"}}
[jbieren@jbieren utils]$ ./merge-json $json1 $json2
{"data":{"foo":"bar","one":"two"}}
[jbieren@jbieren utils]$ ./merge-json $json2 $json3
{"data":{"one":"three"}}
```
without the fix, it was like this
```
[jbieren@jbieren utils]$ ./merge-json $json1 $json2
{"data":{"one":"two"}}
```