### PR TITLE
fix(RHTAPBUGS-927): add image_id back when creating image in Pyxis

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -199,6 +199,7 @@ def create_container_image(args, parsed_data: Dict[str, Any]):
             }
         ],
         "certified": json.loads(args.certified.lower()),
+        "image_id": docker_image_digest,
         "architecture": parsed_data["architecture"],
         "parsed_data": parsed_data,
     }

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -106,6 +106,7 @@ def test_create_container_image(mock_datetime, mock_post, mock_get_digest_field:
                 }
             ],
             "certified": False,
+            "image_id": "some_digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
         },
@@ -167,6 +168,7 @@ def test_create_container_image_latest(
                 }
             ],
             "certified": False,
+            "image_id": "some_digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
         },
@@ -222,6 +224,7 @@ def test_create_container_image_rh_push(
                 }
             ],
             "certified": False,
+            "image_id": "some_digest",
             "architecture": "ok",
             "parsed_data": {"architecture": "ok"},
         },


### PR DESCRIPTION
The field is needed for image grading.

We did set this field in the past, but it was accidentally removed when fixing RHTAPBUGS-756 .