### PR TITLE
feat(RHTAPREL-618): create two repos when pushing to registry.redhat.io

### DIFF
--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -210,6 +210,19 @@ def test_create_container_image_rh_push(
         {
             "repositories": [
                 {
+                    "published": False,
+                    "registry": "quay.io",
+                    "repository": "redhat-pending/some-product----some-image",
+                    "push_date": "1970-10-10T10:10:10.000000+00:00",
+                    "tags": [
+                        {
+                            "added_date": "1970-10-10T10:10:10.000000+00:00",
+                            "name": "some_version",
+                        }
+                    ],
+                    "digest_field": "some_digest",
+                },
+                {
                     "published": True,
                     "registry": "registry.access.redhat.com",
                     "repository": "some-product/some-image",
@@ -221,7 +234,7 @@ def test_create_container_image_rh_push(
                         }
                     ],
                     "digest_field": "some_digest",
-                }
+                },
             ],
             "certified": False,
             "image_id": "some_digest",


### PR DESCRIPTION
Based on discussion with rbean and jvulgan in Slack, we should actually create two items in ContainerImage.repositories for images pushed to registry.redhat.io. The first one will be the same as for other pushes. The second one will have the registry and repository values converted (see the Python script documentation for more details).

The quay.io entry will be used for pulling the image for grading of the image by Clair.