### PR TITLE
refactor(RHTAPBUGS-919): create components in batches

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 95
+extend-ignore = E203

--- a/pyxis/test_pyxis.py
+++ b/pyxis/test_pyxis.py
@@ -86,9 +86,9 @@ def test_graphql_query__success(mock_post: MagicMock):
         }
     }
 
-    data = pyxis.graphql_query(API_URL, REQUEST_BODY, QUERY)
+    data = pyxis.graphql_query(API_URL, REQUEST_BODY)
 
-    assert data == mock_data
+    assert data[QUERY]["data"] == mock_data
     mock_post.assert_called_once_with(API_URL, REQUEST_BODY)
 
 
@@ -102,7 +102,7 @@ def test_graphql_query__general_graphql_error(mock_post: MagicMock):
     }
 
     with pytest.raises(RuntimeError):
-        pyxis.graphql_query(API_URL, REQUEST_BODY, QUERY)
+        pyxis.graphql_query(API_URL, REQUEST_BODY)
 
     mock_post.assert_called_once_with(API_URL, REQUEST_BODY)
 
@@ -121,7 +121,7 @@ def test_graphql_query__pyxis_error(mock_post: MagicMock):
     }
 
     with pytest.raises(RuntimeError):
-        pyxis.graphql_query(API_URL, REQUEST_BODY, QUERY)
+        pyxis.graphql_query(API_URL, REQUEST_BODY)
 
     mock_post.assert_called_once_with(API_URL, REQUEST_BODY)
 

--- a/pyxis/test_upload_sbom.py
+++ b/pyxis/test_upload_sbom.py
@@ -7,7 +7,8 @@ from upload_sbom import (
     get_image,
     create_content_manifest,
     get_existing_bom_refs,
-    create_content_manifest_component,
+    create_content_manifest_components,
+    get_template,
     load_sbom_components,
     check_bom_ref_duplicates,
     convert_keys,
@@ -57,7 +58,7 @@ def test_upload_sbom_with_retry__fails(mock_upload_sbom):
     assert mock_upload_sbom.call_count == 2
 
 
-@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.create_content_manifest_components")
 @patch("upload_sbom.get_existing_bom_refs")
 @patch("upload_sbom.load_sbom_components")
 @patch("upload_sbom.create_content_manifest")
@@ -67,7 +68,7 @@ def test_upload_sbom__success(
     mock_create_content_manifest,
     mock_load_sbom_components,
     mock_get_existing_bom_refs,
-    mock_create_content_manifest_component,
+    mock_create_content_manifest_components,
 ):
     """
     Basic use case - nothing exists in Pyxis yet and all components are successfully created
@@ -86,14 +87,18 @@ def test_upload_sbom__success(
 
     mock_create_content_manifest.assert_called_once_with(GRAPHQL_API, IMAGE_ID)
     mock_get_existing_bom_refs.assert_not_called()
-    assert mock_create_content_manifest_component.call_args_list == [
-        call(GRAPHQL_API, MANIFEST_ID, {"bom_ref": "aaa"}),
-        call(GRAPHQL_API, MANIFEST_ID, {"bom_ref": "bbb"}),
-        call(GRAPHQL_API, MANIFEST_ID, {"type": "library"}),
-    ]
+    mock_create_content_manifest_components.assert_called_once_with(
+        GRAPHQL_API,
+        MANIFEST_ID,
+        [
+            {"bom_ref": "aaa"},
+            {"bom_ref": "bbb"},
+            {"type": "library"},
+        ],
+    )
 
 
-@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.create_content_manifest_components")
 @patch("upload_sbom.load_sbom_components")
 @patch("upload_sbom.create_content_manifest")
 @patch("upload_sbom.get_image")
@@ -101,7 +106,7 @@ def test_upload_sbom__manifest_and_one_component_exist(
     mock_get_image,
     mock_create_content_manifest,
     mock_load_sbom_components,
-    mock_create_content_manifest_component,
+    mock_create_content_manifest_components,
 ):
     """Creation of the manifest and the first component is skipped"""
     mock_get_image.return_value = {
@@ -119,12 +124,12 @@ def test_upload_sbom__manifest_and_one_component_exist(
     upload_sbom(GRAPHQL_API, IMAGE_ID, SBOM_PATH)
 
     mock_create_content_manifest.assert_not_called()
-    mock_create_content_manifest_component.assert_called_once_with(
-        GRAPHQL_API, MANIFEST_ID, {"bom_ref": "bbb"}
+    mock_create_content_manifest_components.assert_called_once_with(
+        GRAPHQL_API, MANIFEST_ID, [{"bom_ref": "bbb"}]
     )
 
 
-@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.create_content_manifest_components")
 @patch("upload_sbom.load_sbom_components")
 @patch("upload_sbom.create_content_manifest")
 @patch("upload_sbom.get_image")
@@ -132,7 +137,7 @@ def test_upload_sbom__all_components_exist(
     mock_get_image,
     mock_create_content_manifest,
     mock_load_sbom_components,
-    mock_create_content_manifest_component,
+    mock_create_content_manifest_components,
 ):
     """Creation of manifest and all components is skipped"""
     mock_get_image.return_value = {
@@ -150,7 +155,7 @@ def test_upload_sbom__all_components_exist(
     upload_sbom(GRAPHQL_API, IMAGE_ID, SBOM_PATH)
 
     mock_create_content_manifest.assert_not_called()
-    mock_create_content_manifest_component.assert_not_called()
+    mock_create_content_manifest_components.assert_not_called()
 
 
 def generate_pyxis_response(query_name, data=None, error=False):
@@ -170,7 +175,7 @@ def generate_pyxis_response(query_name, data=None, error=False):
     return response
 
 
-@patch("upload_sbom.create_content_manifest_component")
+@patch("upload_sbom.create_content_manifest_components")
 @patch("upload_sbom.load_sbom_components")
 @patch("upload_sbom.create_content_manifest")
 @patch("upload_sbom.get_image")
@@ -178,7 +183,7 @@ def test_upload_sbom__existing_bom_ref_is_skipped(
     mock_get_image,
     mock_create_content_manifest,
     mock_load_sbom_components,
-    mock_create_content_manifest_component,
+    mock_create_content_manifest_components,
 ):
     """One component already exists in Pyxis. Our sbom contains two
     components. So we want to upload only the second one to Pyxis,
@@ -200,7 +205,7 @@ def test_upload_sbom__existing_bom_ref_is_skipped(
     upload_sbom(GRAPHQL_API, IMAGE_ID, SBOM_PATH)
 
     mock_create_content_manifest.assert_not_called()
-    mock_create_content_manifest_component.assert_not_called()
+    mock_create_content_manifest_components.assert_called_with(GRAPHQL_API, MANIFEST_ID, [])
 
 
 @patch("pyxis.post")
@@ -316,28 +321,83 @@ def test_get_existing_bom_refs__no_components_result_in_empty_set():
     assert bom_refs == set()
 
 
-@patch("pyxis.post")
-def test_create_content_manifest_component__success(mock_post):
-    mock_post.return_value = generate_pyxis_response(
-        "create_content_manifest_component_for_manifest", {"_id": COMPONENT_ID}
+@patch("pyxis.graphql_query")
+@patch("upload_sbom.get_template")
+def test_create_content_manifest_components__success(mock_get_template, mock_graphql_query):
+    create_content_manifest_components(
+        GRAPHQL_API, MANIFEST_ID, [COMPONENT_DICT], batch_size=2
     )
 
-    id = create_content_manifest_component(GRAPHQL_API, MANIFEST_ID, COMPONENT_DICT)
+    mock_get_template.assert_called_once_with()
+    mock_get_template.return_value.render.assert_called_once_with(components=[COMPONENT_DICT])
+    mock_graphql_query.assert_called_once()
 
-    assert id == COMPONENT_ID
-    mock_post.assert_called_once()
+
+@patch("pyxis.graphql_query")
+@patch("upload_sbom.get_template")
+def test_create_content_manifest_component__multiple_batches(
+    mock_get_template, mock_graphql_query
+):
+    comp1 = {"bom_ref": "aaa"}
+    comp2 = {"bom_ref": "bbb"}
+    comp3 = {"type": "library"}
+    components = [comp1, comp2, comp3]
+
+    create_content_manifest_components(GRAPHQL_API, MANIFEST_ID, components, batch_size=2)
+
+    mock_get_template.assert_called_once_with()
+    assert mock_get_template.return_value.render.call_args_list == [
+        call(components=[comp1, comp2]),
+        call(components=[comp3]),
+    ]
+    assert mock_graphql_query.call_count == 2
+    assert mock_graphql_query.call_args_list == [
+        call(
+            GRAPHQL_API,
+            {
+                "query": mock_get_template.return_value.render.return_value,
+                "variables": {
+                    "id": MANIFEST_ID,
+                    "input0": comp1,
+                    "input1": comp2,
+                },
+            },
+        ),
+        call(
+            GRAPHQL_API,
+            {
+                "query": mock_get_template.return_value.render.return_value,
+                "variables": {
+                    "id": MANIFEST_ID,
+                    "input0": comp3,
+                },
+            },
+        ),
+    ]
 
 
-@patch("pyxis.post")
-def test_create_content_manifest_component__error(mock_post):
-    mock_post.return_value = generate_pyxis_response(
-        "create_content_manifest_component_for_manifest", error=True
-    )
+@patch("pyxis.graphql_query")
+@patch("upload_sbom.get_template")
+def test_create_content_manifest_component__no_components(
+    mock_get_template, mock_graphql_query
+):
+    create_content_manifest_components(GRAPHQL_API, MANIFEST_ID, [])
 
-    with pytest.raises(RuntimeError):
-        create_content_manifest_component(GRAPHQL_API, MANIFEST_ID, COMPONENT_DICT)
+    mock_get_template.assert_not_called()
+    mock_graphql_query.assert_not_called()
 
-    mock_post.assert_called_once()
+
+@patch("upload_sbom.Template")
+@patch("builtins.open")
+@patch("upload_sbom.os")
+def test_get_template(mock_os, mock_open, mock_template):
+    template_path = mock_os.path.join.return_value
+
+    template = get_template()
+
+    mock_open.assert_called_with(template_path)
+    assert template == mock_template.return_value
+    mock_open.return_value.__enter__.return_value.read.assert_called_once_with()
 
 
 @patch("json.load")

--- a/pyxis/upload_sbom.py
+++ b/pyxis/upload_sbom.py
@@ -241,9 +241,8 @@ def create_content_manifest_components(
         LOGGER.info(f"Adding component {i+1} to {i+len(batch)}")
         mutation = template.render(components=batch)
 
-        variables = {"id": content_manifest_id}
-        for j, component in enumerate(batch):
-            variables[f"input{j}"] = component
+        variables = {f"input{j}": component for j, component in enumerate(batch)}
+        variables["id"] = content_manifest_id
 
         body = {"query": mutation, "variables": variables}
 

--- a/pyxis/upload_sbom.py
+++ b/pyxis/upload_sbom.py
@@ -26,6 +26,7 @@ import re
 from pathlib import Path
 import time
 from typing import Any
+from jinja2 import Template
 
 import pyxis
 
@@ -39,6 +40,7 @@ UNSUPPORTED_FIELDS = [
     "signature",
     "components",
 ]
+TEMPLATE_FILE = "create_content_manifest_components.graphql.jinja"
 
 
 def parse_arguments() -> argparse.Namespace:  # pragma: no cover
@@ -120,12 +122,14 @@ def upload_sbom(graphql_api: str, image_id: str, sbom_path: str):
     else:
         existing_bom_refs = set()
 
+    components = []
+
     for i in range(existing_component_count, sbom_component_count):
+        LOGGER.info(f"Processing component {i+1}/{sbom_component_count}")
+
         component = sbom_components[i]
         component = convert_keys(component)
         remove_unsupported_fields(component)
-
-        LOGGER.info(f"Processing component {i+1}/{sbom_component_count}")
 
         # bom-ref is not required, but has to be unique for
         # a given sbom. In most cases it is defined.
@@ -138,11 +142,9 @@ def upload_sbom(graphql_api: str, image_id: str, sbom_path: str):
             else:
                 existing_bom_refs.add(component["bom_ref"])
 
-        component_id = create_content_manifest_component(
-            graphql_api, content_manifest_id, component
-        )
-        if component_id is not None:
-            LOGGER.info(f"Component ID: {component_id}")
+        components.append(component)
+
+    create_content_manifest_components(graphql_api, content_manifest_id, components)
 
 
 def get_image(graphql_api: str, image_id: str, page_size: int = 50) -> dict:
@@ -183,7 +185,8 @@ query ($id: ObjectIDFilterScalar!, $page: Int!, $page_size: Int!) {
         variables = {"id": image_id, "page": page, "page_size": page_size}
         body = {"query": query, "variables": variables}
 
-        image = pyxis.graphql_query(graphql_api, body, "get_image")
+        data = pyxis.graphql_query(graphql_api, body)
+        image = data["get_image"]["data"]
 
         components_batch = image["edges"]["content_manifest_components"]["data"]
         components.extend(components_batch)
@@ -211,9 +214,9 @@ mutation ($input: ContentManifestInput! ) {
     variables = {"input": {"image": {"_id": image_id}}}
     body = {"query": mutation, "variables": variables}
 
-    data = pyxis.graphql_query(graphql_api, body, "create_content_manifest")
+    data = pyxis.graphql_query(graphql_api, body)
 
-    return data["_id"]
+    return data["create_content_manifest"]["data"]["_id"]
 
 
 def get_existing_bom_refs(components: list) -> set[str]:
@@ -221,30 +224,38 @@ def get_existing_bom_refs(components: list) -> set[str]:
     return set(bom_refs)
 
 
-def create_content_manifest_component(
-    graphql_api: str, content_manifest_id: str, component: dict
-) -> str:
-    """Create ContentManifestComponent object in Pyxis using GraphQL API"""
-    mutation = """
-mutation ($id: ObjectIDFilterScalar!, $input: ContentManifestComponentInput! ) {
-    create_content_manifest_component_for_manifest(id: $id, input: $input) {
-        data {
-            _id
-        }
-        error {
-            detail
-        }
-    }
-}
-"""
-    variables = {"id": content_manifest_id, "input": component}
-    body = {"query": mutation, "variables": variables}
+def create_content_manifest_components(
+    graphql_api: str, content_manifest_id: str, components: list[dict], batch_size: int = 5
+):
+    """Create ContentManifestComponent objects in Pyxis using GraphQL API.
 
-    data = pyxis.graphql_query(
-        graphql_api, body, "create_content_manifest_component_for_manifest"
-    )
+    Components will be created in batches.
+    """
+    if not components:
+        LOGGER.info("No components to be created - skipping component creation")
+        return
+    LOGGER.info(f"Creating {len(components)} components in Pyxis...")
+    template = get_template()
+    for i in range(0, len(components), batch_size):
+        batch = components[i : i + batch_size]
+        LOGGER.info(f"Adding component {i+1} to {i+len(batch)}")
+        mutation = template.render(components=batch)
 
-    return data["_id"]
+        variables = {"id": content_manifest_id}
+        for j, component in enumerate(batch):
+            variables[f"input{j}"] = component
+
+        body = {"query": mutation, "variables": variables}
+
+        pyxis.graphql_query(graphql_api, body)
+
+
+def get_template() -> Template:
+    script_dir = os.path.dirname(__file__)
+    template_path = os.path.join(script_dir, "../templates/", TEMPLATE_FILE)
+    with open(template_path) as t:
+        template = Template(t.read())
+    return template
 
 
 def load_sbom_components(sbom_path: str) -> list[dict]:

--- a/templates/create_content_manifest_components.graphql.jinja
+++ b/templates/create_content_manifest_components.graphql.jinja
@@ -1,0 +1,20 @@
+mutation (
+    $id: ObjectIDFilterScalar!,
+    {% for component in components %}
+    $input{{ loop.index0 }}: ContentManifestComponentInput!{% if not loop.last %},{% endif %}
+    {% endfor %}
+) {
+    {% for component in components %}
+    create{{ loop.index0 }}: create_content_manifest_component_for_manifest(
+        id: $id,
+        input: $input{{ loop.index0 }}
+    ) {
+        data {
+            _id
+        }
+        error {
+            detail
+        }
+    }
+    {% endfor %}
+}


### PR DESCRIPTION
By creating sbom components in Pyxis in batches
of 5, the overall script runtime is reduced by around
47 % in my testing with an sbom with 113 components.

The batch size is configurable, but currently set to 5.

Note that this is a follow up of https://github.com/redhat-appstudio/release-service-utils/pull/91 which is merged now.