### PR TITLE
fix(RHTAPBUGS-972): add option source container enabled option for pyxis

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -86,6 +86,11 @@ def setup_argparser() -> Any:  # pragma: no cover
         required=True,
     )
     parser.add_argument(
+        "--source-container-enabled",
+        help="Were source container images published alongside the image?",
+        default="false",
+    )
+    parser.add_argument(
         "--media-type",
         help="The mediaType string returned by `skopeo inspect --raw`. "
         "Used to determine if it's a single arch or multiarch image.",
@@ -197,6 +202,7 @@ def create_container_image(args, parsed_data: Dict[str, Any]):
                 "repository": image_repo,
                 "push_date": date_now,
                 "tags": pyxis_tags,
+                "source_container_image_enabled": (args.source_container_enabled == "true"),
             }
         ],
         "certified": json.loads(args.certified.lower()),

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -78,6 +78,7 @@ def test_create_container_image(mock_datetime, mock_post, mock_get_digest_field:
     args.tags = "some_version"
     args.certified = "false"
     args.rh_push = "false"
+    args.source_container_enabled = "true"
     mock_get_digest_field.return_value = "digest_field"
 
     # Act
@@ -103,6 +104,7 @@ def test_create_container_image(mock_datetime, mock_post, mock_get_digest_field:
                         }
                     ],
                     "digest_field": "some_digest",
+                    "source_container_image_enabled": True,
                 }
             ],
             "certified": False,
@@ -165,6 +167,7 @@ def test_create_container_image_latest(
                         },
                     ],
                     "digest_field": "some_digest",
+                    "source_container_image_enabled": False,
                 }
             ],
             "certified": False,
@@ -225,6 +228,7 @@ def test_create_container_image_rh_push_multiple_tags(
                         },
                     ],
                     "digest_field": "some_digest",
+                    "source_container_image_enabled": False,
                 },
                 {
                     "published": True,
@@ -242,6 +246,7 @@ def test_create_container_image_rh_push_multiple_tags(
                         },
                     ],
                     "digest_field": "some_digest",
+                    "source_container_image_enabled": False,
                 },
             ],
             "certified": False,


### PR DESCRIPTION
Add the ability to pass whether or not the source container image is enabled when creating ContainerImage entries in Pyxis. The default is false.