### PR TITLE
feat(RHTAPSRE-287): use new group name in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @redhat-appstudio/release-team will be requested for
+# @redhat-appstudio/konflux-release-team will be requested for
 # review when someone opens a pull request.
-*       @redhat-appstudio/release-team
+*       @redhat-appstudio/konflux-release-team


### PR DESCRIPTION
A new GitHub group named `konflux-release-team` was created to replace `Release Team`. Use new one to be able to delete former one.

The context of this new group name is to align with new service name but also with the name of existing Rover group. Having both GitHub and Rover group names aligned will allow to have clusters auth with either GitHub or Red Hat SSO without having any difference in the RBACs.