### PR TITLE
fix(RHTAPREL-857): handle case when there is no content_manifest yet

### DIFF
--- a/pyxis/test_upload_sbom.py
+++ b/pyxis/test_upload_sbom.py
@@ -24,7 +24,15 @@ COMPONENT_ID = "abcd2222"
 IMAGE_DICT = {
     "_id": IMAGE_ID,
     "content_manifest": None,
-    "edges": {"content_manifest_components": {"data": []}},
+    "edges": {
+        "content_manifest_components": {
+            "data": None,
+            "error": {
+                "status": 400,
+                "detail": "Value content_manifest._id is not in the parent object",
+            },
+        }
+    },
 }
 COMPONENT_DICT = {"bom_ref": "mybomref"}
 

--- a/pyxis/upload_sbom.py
+++ b/pyxis/upload_sbom.py
@@ -168,10 +168,15 @@ query ($id: ObjectIDFilterScalar!, $page: Int!, $page_size: Int!) {
                         _id
                         bom_ref
                     }
+                    error {
+                        status
+                        detail
+                    }
                 }
             }
         }
         error {
+            status
             detail
         }
     }
@@ -187,6 +192,10 @@ query ($id: ObjectIDFilterScalar!, $page: Int!, $page_size: Int!) {
 
         data = pyxis.graphql_query(graphql_api, body)
         image = data["get_image"]["data"]
+
+        if image["content_manifest"] is None:
+            # There will be no components, so no need to proceed
+            break
 
         components_batch = image["edges"]["content_manifest_components"]["data"]
         components.extend(components_batch)


### PR DESCRIPTION
In the upload_sbom script, when we initially start processing an image, there will be no associated content_manifest yet. Previously, the content_manifest_components edge would still return an empty array in its data field and we relied on it.

But the correct behavior is to return an error for the edge instead and the Pyxis team deployed this change which broke our script. They reverted the change until we address it which is happening with this change.

This adds a check so that when there is no content_manifest, we don't even check the components.

More error handling will be added later.