### PR TITLE
feat(RHTAPREL-799): add updated_date to advisory template

### DIFF
--- a/templates/advisory.yaml.jinja
+++ b/templates/advisory.yaml.jinja
@@ -3,6 +3,7 @@ kind: Advisory
 metadata:
   name: {{ advisory_name }}
   ship_date: {{ advisory_ship_date }}
+  updated_date: {{ advisory_ship_date }}
 spec:
   product_id: {{ advisory.spec.product_id }}
   product_name: {{ advisory.spec.product_name }}


### PR DESCRIPTION
This field will initially have the same value
as ship_date. The intention is that it will be updated manually if the advisory is updated in the gitlab repo in the future.