### PR TITLE
fix: handle null Env from skopeo

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -151,7 +151,7 @@ def prepare_parsed_data(skopeo_result: Dict[str, Any]) -> Dict[str, Any]:
         "layers": skopeo_result.get("Layers", []),
         "name": skopeo_result.get("Name", ""),
         "architecture": skopeo_result.get("Architecture", ""),
-        "env_variables": skopeo_result.get("Env", []),
+        "env_variables": skopeo_result.get("Env", []) or [],
     }
 
 

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -304,6 +304,31 @@ def test_prepare_parsed_data():
     }
 
 
+def test_prepare_parsed_data_with_null_env():
+    # Arrange
+    file_content = {
+        "Digest": "sha:abc",
+        "DockerVersion": "1",
+        "Layers": ["1", "2"],
+        "Name": "quay.io/hacbs-release/release-service-utils",
+        "Architecture": "test",
+        "Env": None,
+    }
+
+    # Act
+    parsed_data = prepare_parsed_data(file_content)
+
+    # Assert
+    assert parsed_data == {
+        "architecture": "test",
+        "digest": "sha:abc",
+        "docker_version": "1",
+        "env_variables": [],
+        "layers": ["1", "2"],
+        "name": "quay.io/hacbs-release/release-service-utils",
+    }
+
+
 def test_get_digest_field():
     """This will test that the common mediaType strings are translated to the correct
     digest field to be used in the image.repository object"""


### PR DESCRIPTION
The pyxis schema can only accept an array here, not None, however skopeo can return null/None. Here, if the value is falsy, then use an empty array rather than the falsy value.