### PR TITLE
feat(RHTAPREL-863): return both redhat registries with util

### DIFF
--- a/utils/translate-delivery-repo
+++ b/utils/translate-delivery-repo
@@ -2,9 +2,11 @@
 #
 # script:      translate-delivery-repo
 # 
-# description: This script translates repo references to the proper public registry reference.
+# description: This script translates repo references to the proper public registry references.
 #              It turns quay.io/redhat-prod/product----repo into registry.redhat.io/product/repo for production repos and
-#              quay.io/redhat-pending/product----repo -> registry.stage.redhat.io/product/repo for stage repos.
+#              quay.io/redhat-pending/product----repo -> registry.stage.redhat.io/product/repo for stage repos. It outputs a
+#              json string with two entries. Each entry is of the form repo: [redhat.io, access.redhat.com],
+#              url: <translated-delivery-repo>. 
 #
 # example command:  
 #              translate-delivery-repo REPO where REPO is quay.io/redhat-prod/product----repo for example
@@ -17,15 +19,27 @@ if [ -z "${REPO}" ]; then
     exit 1
 fi
 
-if [[ "${REPO}" != "quay.io/redhat-prod"* && "${REPO}" != "quay.io/redhat-pending"* ]] ||
-    [[ "${REPO}" != *"----"* ]] ; then
-    echo -n "Warning: Repo to translate is not in expected format. If this is not an index " >&2
-    echo "image, the expected format is: quay.io/redhat-[prod,pending]/product----repo" >&2
-fi
-
-REPO=${REPO/quay.io\/redhat-prod/registry.redhat.io}
-REPO=${REPO/quay.io\/redhat-pending/registry.stage.redhat.io}
-REPO=${REPO/quay.io\/redhat/registry.redhat.io} # Index image repos don't have -prod or -pending
 REPO=${REPO//----//}
 
-echo "${REPO}"
+case "${REPO}" in
+  "quay.io/redhat-prod/"*)
+    IO_URL=${REPO/quay.io\/redhat-prod/registry.redhat.io}
+    ACCESS_URL=$(echo "${IO_URL}" | sed 's/^registry.redhat.io/registry.access.redhat.com/')
+    ;;
+  "quay.io/redhat-pending/"*)
+    IO_URL=${REPO/quay.io\/redhat-pending/registry.stage.redhat.io}
+    ACCESS_URL=$(echo "${IO_URL}" | sed 's/^registry.stage.redhat.io/registry.access.stage.redhat.com/')
+    ;;
+  "quay.io/redhat/"*) # Index image repos don't have -prod or -pending
+    IO_URL=${REPO/quay.io\/redhat/registry.redhat.io}
+    ACCESS_URL=$(echo "${IO_URL}" | sed 's/^registry.redhat.io/registry.access.redhat.com/')
+    ;;
+  *)
+    echo -n "Warning: Repo to translate is not in expected format. If this is not an index " >&2
+    echo "image, the expected format is: quay.io/redhat-[prod,pending]/product----repo" >&2
+    IO_URL=$REPO
+    ACCESS_URL=""
+    ;;
+esac
+
+echo '[{"repo":"redhat.io","url":"'$IO_URL'"},{"repo":"access.redhat.com","url":"'$ACCESS_URL'"}]'


### PR DESCRIPTION
This commit updates the translate-delivery-repo to return a JSON string that has both the registry.redhat.io repo and the
registry.access.redhat.com repo (and their stage versions).